### PR TITLE
Add test namespace for team validator

### DIFF
--- a/.github/workflows/team-validator.yaml
+++ b/.github/workflows/team-validator.yaml
@@ -12,6 +12,8 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  # Add permission to read team membership
+  organization-administration: read
 
 jobs:
   validate:

--- a/.github/workflows/team-validator.yaml
+++ b/.github/workflows/team-validator.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Validate Team Membership
-        uses: Gnomon-iterative/github-team-validator@v1.0.0
+        uses: Gnomon-iterative/github-team-validator@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/team-validator.yaml
+++ b/.github/workflows/team-validator.yaml
@@ -1,0 +1,21 @@
+name: Team Validator
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'namespaces/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Team Validator
+        uses: Gnomon-iterative/github-team-validator@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          organization: 'Gnomon-iterative'

--- a/.github/workflows/team-validator.yaml
+++ b/.github/workflows/team-validator.yaml
@@ -2,6 +2,7 @@ name: Team Validator
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
     paths:

--- a/.github/workflows/team-validator.yaml
+++ b/.github/workflows/team-validator.yaml
@@ -7,15 +7,21 @@ on:
     paths:
       - 'namespaces/**'
 
+# Add permissions block to allow commenting on PRs
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Run Team Validator
-        uses: Gnomon-iterative/github-team-validator@main
+      - uses: actions/checkout@v4
+      
+      - name: Validate Team Membership
+        uses: Gnomon-iterative/github-team-validator@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
-          organization: 'Gnomon-iterative'
+          organization: Gnomon-iterative

--- a/namespaces/test-namespace.yaml
+++ b/namespaces/test-namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-namespace 
+  name: test-namespace
   annotations:
     team: data-insights 
     source-code: https://github.com/Gnomon-iterative/cloud-cost

--- a/namespaces/test-namespace.yaml
+++ b/namespaces/test-namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-namespace
+  name: test-namespace 
   annotations:
     team: data-insights 
     source-code: https://github.com/Gnomon-iterative/cloud-cost

--- a/namespaces/test-namespace.yaml
+++ b/namespaces/test-namespace.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: test-namespace
   annotations:
-    team: data-insights
+    team: data-insights 
     source-code: https://github.com/Gnomon-iterative/cloud-cost

--- a/namespaces/test-namespace.yaml
+++ b/namespaces/test-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+  annotations:
+    team: data-insights
+    source-code: https://github.com/Gnomon-iterative/cloud-cost

--- a/namespaces/test-namespace.yaml
+++ b/namespaces/test-namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   annotations:
     team: data-insights 
     source-code: https://github.com/Gnomon-iterative/cloud-cost
+  # Add comment to trigger workflow


### PR DESCRIPTION
This PR adds:
1. A test namespace file with team annotation (data-insights) and source-code annotation
2. GitHub Actions workflow that uses the team validator from github-team-validator repo

The workflow will:
- Check if PR author belongs to data-insights team
- Verify if source-code repo exists and is public
- Check for LGTM comments from team members if needed